### PR TITLE
feat: Add Storage.php for handling file reading/writing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ $RECYCLE.BIN/
 # Generated XML files from tests
 /tests/*.xml
 composer.lock
+/.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ First, generate a **certificate signing request (CSR)** and private key:
 
 ```php
 use Saleh7\Zatca\CertificateBuilder;
-use Saleh7\Zatca\CertificateBuilderException;
+use Saleh7\Zatca\Exceptions\CertificateBuilderException;
 
 try {
     (new CertificateBuilder())
@@ -166,7 +166,7 @@ use Saleh7\Zatca\{
     InvoiceType, AdditionalDocumentReference, TaxScheme, PartyTaxScheme, Address, LegalEntity, Delivery, 
     Party, PaymentMeans, TaxCategory, AllowanceCharge, TaxSubTotal, TaxTotal, LegalMonetaryTotal, 
     ClassifiedTaxCategory, Item, Price, InvoiceLine, GeneratorInvoice, Invoice, UnitCode, 
-    OrderReference, BillingReference, Contract, Attachment
+    OrderReference, BillingReference, Contract, Attachment, Storage
 };
 
 // --- Invoice Type ---
@@ -288,7 +288,7 @@ try {
     
     // Save the XML to a file
     $filePath = __DIR__ . '/output/unsigned_invoice.xml';
-    file_put_contents($filePath, $outputXML);
+    (new Storage)->put($filePath, $outputXML);
     
     echo "Invoice XML saved to: " . $filePath . "\n";
 
@@ -305,22 +305,23 @@ Before submitting the invoice to **ZATCA**, we need to **digitally sign** it usi
 ```php
 use Saleh7\Zatca\Helpers\Certificate;
 use Saleh7\Zatca\InvoiceSigner;
+use Saleh7\Zatca\Storage;
 
 // Load the unsigned invoice XML
-$xmlInvoice = file_get_contents(__DIR__ . '/output/unsigned_invoice.xml');
+$xmlInvoice = (new Storage)->get(__DIR__ . '/output/unsigned_invoice.xml');
 
 // Load the compliance certificate data from the JSON file
-$json_certificate = file_get_contents(__DIR__ . '/output/ZATCA_certificate_data.json');
+$json_certificate = (new Storage)->get(__DIR__ . '/output/ZATCA_certificate_data.json');
 
 // Decode the JSON data
 $json_data = json_decode($json_certificate, true, 512, JSON_THROW_ON_ERROR);
 
 // Extract certificate details
-$certificate = $json_data[0]['certificate'];
-$secret = $json_data[0]['secret'];
+$certificate = $json_data['certificate'];
+$secret = $json_data['secret'];
 
 // Load the private key
-$privateKey = file_get_contents(__DIR__ . '/output/private.pem');
+$privateKey = (new Storage)->put(__DIR__ . '/output/private.pem');
 $cleanPrivateKey = trim(str_replace(["-----BEGIN PRIVATE KEY-----", "-----END PRIVATE KEY-----"], "", $privateKey));
 
 // Create a Certificate instance

--- a/examples/GeneratorCertificate.php
+++ b/examples/GeneratorCertificate.php
@@ -2,7 +2,7 @@
 require __DIR__ . '/../vendor/autoload.php';
 
 use Saleh7\Zatca\CertificateBuilder;
-use Saleh7\Zatca\CertificateBuilderException;
+use Saleh7\Zatca\Exceptions\CertificateBuilderException;
 
 
 // Usage example:

--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -5,6 +5,7 @@ namespace Saleh7\Zatca;
 use Exception;
 use InvalidArgumentException;
 
+use Saleh7\Zatca\Exceptions\ZatcaStorageException;
 use function Sabre\Xml\Deserializer\mixedContent;
 
 use Sabre\Xml\Reader;
@@ -150,13 +151,14 @@ class Attachment implements XmlSerializable, XmlDeserializable
      *
      * @param Writer $writer
      * @return void
+     * @throws ZatcaStorageException
      */
     public function xmlSerialize(Writer $writer): void
     {
         $this->validate();
 
         if (!empty($this->filePath)) {
-            $fileContents = base64_encode(file_get_contents($this->filePath));
+            $fileContents = base64_encode((new Storage)->get($this->filePath));
             $fileName = basename($this->filePath);
             $mimeType = $this->getFilePathMimeType();
         } else {

--- a/src/Exceptions/CertificateBuilderException.php
+++ b/src/Exceptions/CertificateBuilderException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Saleh7\Zatca\Exceptions;
+
+/**
+ * Exception for CertificateBuilder errors.
+ */
+class CertificateBuilderException extends ZatcaException {}

--- a/src/Exceptions/ZatcaStorageException.php
+++ b/src/Exceptions/ZatcaStorageException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Saleh7\Zatca\Exceptions;
+
+/**
+ * Exception for Storage errors.
+ */
+class ZatcaStorageException extends ZatcaException {}

--- a/src/GeneratorInvoice.php
+++ b/src/GeneratorInvoice.php
@@ -2,6 +2,7 @@
 namespace Saleh7\Zatca;
 
 use Sabre\Xml\Service;
+use Saleh7\Zatca\Exceptions\ZatcaStorageException;
 
 /**
  * Class GeneratorInvoice
@@ -49,23 +50,13 @@ class GeneratorInvoice
      * Saves the generated invoice as an XML file.
      *
      * @param string $filename (Optional) File path to save the XML.
+     * @param string|null $outputDir (Optional) Directory name. Set to null if $filename contains the full file path.
      * @return self
+     * @throws ZatcaStorageException If the XML file cannot be saved.
      */
-    public function saveXMLFile(string $filename = 'unsigned_invoice.xml'): self
+    public function saveXMLFile(string $filename = 'unsigned_invoice.xml', ?string $outputDir = 'output'): self
     {
-        $outputDir = 'output';
-        
-        if (!is_dir($outputDir)) {
-            mkdir($outputDir, 0777, true);
-        }
-
-        $fullPath = "{$outputDir}/{$filename}";
-
-        if (file_put_contents($fullPath, $this->generatedXml) === false) {
-            throw new \Exception("Failed to save XML to file: {$fullPath}");
-        }
-
-        echo "Invoice XML saved to: {$fullPath}\n";
+        (new Storage($outputDir))->put($filename, $this->generatedXml);
         return $this;
     }
 

--- a/src/InvoiceSigner.php
+++ b/src/InvoiceSigner.php
@@ -2,6 +2,7 @@
 
 namespace Saleh7\Zatca;
 
+use Saleh7\Zatca\Exceptions\ZatcaStorageException;
 use Saleh7\Zatca\Helpers\QRCodeGenerator;
 use Saleh7\Zatca\Helpers\Certificate;
 use Saleh7\Zatca\Helpers\InvoiceExtension;
@@ -83,23 +84,13 @@ class InvoiceSigner
      * Saves the signed invoice as an XML file.
      *
      * @param string $filename (Optional) File path to save the XML.
+     * @param string|null $outputDir (Optional) Directory name. Set to null if $filename contains the full file path.
      * @return self
+     * @throws ZatcaStorageException If the XML file cannot be saved.
      */
-    public function saveXMLFile(string $filename = 'signed_invoice.xml'): self
+    public function saveXMLFile(string $filename = 'signed_invoice.xml', ?string $outputDir = 'output'): self
     {
-        $outputDir = 'output';
-        
-        if (!is_dir($outputDir)) {
-            mkdir($outputDir, 0777, true);
-        }
-
-        $fullPath = "{$outputDir}/{$filename}";
-
-        if (file_put_contents($fullPath, $this->signedInvoice) === false) {
-            throw new \Exception("Failed to save signed XML to file: {$fullPath}");
-        }
-
-        echo "Signed Invoice XML saved to: {$fullPath}\n";
+        (new Storage($outputDir))->put($filename, $this->signedInvoice);
         return $this;
     }
 

--- a/src/InvoiceSigner.php
+++ b/src/InvoiceSigner.php
@@ -95,6 +95,16 @@ class InvoiceSigner
     }
 
     /**
+     * Get the signed XML string.
+     *
+     * @return string
+     */
+    public function getXML(): string
+    {
+        return $this->signedInvoice;
+    }
+
+    /**
      * Returns the QR node string.
      *
      * @param string $QRCode

--- a/src/Storage.php
+++ b/src/Storage.php
@@ -124,17 +124,14 @@ class Storage
      *
      * @param string $file Relative or full path of the file.
      * @return string Absolute path to the file.
-     * @throws ZatcaStorageException If basePath is not set.
      */
     public function path(string $file): string
     {
-        if (!self::$basePath && !realpath($file)) {
-            throw new ZatcaStorageException("Base path is not set, and no absolute path provided.", [
-                'file' => $file,
-            ]);
+        if (self::$basePath) {
+            return self::$basePath . DIRECTORY_SEPARATOR . $file;
         }
 
-        return self::$basePath ? self::$basePath . DIRECTORY_SEPARATOR . $file : $file;
+        return $file;
     }
 
     /**

--- a/src/Storage.php
+++ b/src/Storage.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Saleh7\Zatca;
+
+use Saleh7\Zatca\Exceptions\ZatcaStorageException;
+
+class Storage
+{
+    private static ?string $basePath = null;
+
+    /**
+     * Constructor to set base storage path.
+     *
+     * @param string|null $basePath Root directory for storage. Set to null if you want to handle files with a full path.
+     */
+    public function __construct(?string $basePath = null)
+    {
+        if ($basePath) {
+            self::$basePath = rtrim($basePath, DIRECTORY_SEPARATOR);
+        }
+    }
+
+    /**
+     * Sets a global base storage path.
+     *
+     * @param string $path The base directory.
+     */
+    public static function setBasePath(string $path): void
+    {
+        self::$basePath = rtrim($path, DIRECTORY_SEPARATOR);
+    }
+
+    /**
+     * Writes data to a file, creating directories if necessary.
+     *
+     * @param string $path Relative or full path of the file.
+     * @param string $content Content to write.
+     * @return bool True if writing was successful, false otherwise.
+     * @throws ZatcaStorageException If the file cannot be written.
+     */
+    public function put(string $path, string $content): bool
+    {
+        $fullPath = $this->path($path);
+        $directory = dirname($fullPath);
+
+        $this->ensureDirectoryExists($directory);
+
+        if (file_put_contents($fullPath, $content) === false) {
+            throw new ZatcaStorageException("Failed to write to file.", [
+                'path' => $fullPath,
+            ]);
+        }
+
+        return true;
+    }
+
+    /**
+     * Appends data to a file, creating directories if necessary.
+     *
+     * @param string $path Relative or full path of the file.
+     * @param string $content Content to append.
+     * @return bool True if writing was successful, false otherwise.
+     * @throws ZatcaStorageException If the file cannot be written.
+     */
+    public function append(string $path, string $content): bool
+    {
+        $fullPath = $this->path($path);
+        $directory = dirname($fullPath);
+
+        $this->ensureDirectoryExists($directory);
+
+        if (file_put_contents($fullPath, $content, FILE_APPEND) === false) {
+            throw new ZatcaStorageException("Failed to append to file.", [
+                'path' => $fullPath,
+            ]);
+        }
+
+        return true;
+    }
+
+    /**
+     * Reads content from a file.
+     *
+     * @param string $path Relative or full path of the file.
+     * @return string The file contents.
+     * @throws ZatcaStorageException If the file does not exist or cannot be read.
+     */
+    public function get(string $path): string
+    {
+        $fullPath = $this->path($path);
+
+        if (!file_exists($fullPath)) {
+            throw new ZatcaStorageException("File not found.", [
+                'path' => $fullPath,
+            ]);
+        }
+
+        $content = file_get_contents($fullPath);
+
+        if ($content === false) {
+            throw new ZatcaStorageException("Failed to read file.", [
+                'path' => $fullPath,
+            ]);
+        }
+
+        return $content;
+    }
+
+    /**
+     * Checks if a file exists.
+     *
+     * @param string $path Relative or full path of the file.
+     *
+     * @return bool True if the file exists, false otherwise.
+     * @throws ZatcaStorageException
+     */
+    public function exists(string $path): bool
+    {
+        return file_exists($this->path($path));
+    }
+
+    /**
+     * Returns the full path of a file.
+     *
+     * @param string $file Relative or full path of the file.
+     * @return string Absolute path to the file.
+     * @throws ZatcaStorageException If basePath is not set.
+     */
+    public function path(string $file): string
+    {
+        if (!self::$basePath && !realpath($file)) {
+            throw new ZatcaStorageException("Base path is not set, and no absolute path provided.", [
+                'file' => $file,
+            ]);
+        }
+
+        return self::$basePath ? self::$basePath . DIRECTORY_SEPARATOR . $file : $file;
+    }
+
+    /**
+     * Ensures the directory exists, creates it if needed.
+     *
+     * @param string $path Directory path.
+     * @throws ZatcaStorageException If the directory cannot be created.
+     */
+    protected function ensureDirectoryExists(string $path): void
+    {
+        if (!$path) {
+            return;
+        }
+
+        // If directory exists but is not writable, throw exception
+        if (is_dir($path) && !is_writable($path)) {
+            throw new ZatcaStorageException('Directory exists but is not writable.', ['path' => $path]);
+        }
+
+        // If parent directory is not writable, fail before mkdir()
+        $parentDir = dirname($path);
+        if (!is_writable($parentDir)) {
+            throw new ZatcaStorageException('Parent directory is not writable.', ['path' => $parentDir]);
+        }
+
+        // If directory does not exist, attempt to create it
+        if (!is_dir($path) && !mkdir($path, 0777, true) && !is_dir($path)) {
+            throw new ZatcaStorageException('Failed to create directory.', ['path' => $path]);
+        }
+    }
+}

--- a/src/ZatcaAPI.php
+++ b/src/ZatcaAPI.php
@@ -10,6 +10,7 @@ use Saleh7\Zatca\Api\ComplianceCertificateResult;
 use Saleh7\Zatca\Api\ProductionCertificateResult;
 use Saleh7\Zatca\Exceptions\ZatcaApiException;
 use InvalidArgumentException;
+use Saleh7\Zatca\Exceptions\ZatcaStorageException;
 
 /**
  * ZATCA E-Invoicing API Client for compliance and reporting operations.
@@ -323,7 +324,8 @@ class ZatcaAPI
      * @param string $requestId   The request ID.
      * @param string $filePath    Path to save the JSON file.
      * @return void
-     * @throws \Exception If file cannot be written.
+     * @throws \Exception If failed to encode data to JSON
+     * @throws ZatcaStorageException If file cannot be written.
      */
     public function saveToJson(string $certificate, string $secret, string $requestId, string $filePath): void
     {
@@ -338,9 +340,7 @@ class ZatcaAPI
             throw new \Exception("Failed to encode data to JSON: " . json_last_error_msg());
         }
 
-        if (file_put_contents($filePath, $json) === false) {
-            throw new \Exception("Failed to write JSON data to file: {$filePath}");
-        }
+        (new Storage)->put($filePath, $json);
     }
     
 }

--- a/tests/CertificateBuilderTest.php
+++ b/tests/CertificateBuilderTest.php
@@ -1,7 +1,7 @@
 <?php
 use PHPUnit\Framework\TestCase;
 use Saleh7\Zatca\CertificateBuilder;
-use Saleh7\Zatca\CertificateBuilderException;
+use Saleh7\Zatca\Exceptions\CertificateBuilderException;
 
 final class CertificateBuilderTest extends TestCase
 {

--- a/tests/StorageTest.php
+++ b/tests/StorageTest.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace Saleh7\Zatca\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Saleh7\Zatca\Storage;
+use Saleh7\Zatca\Exceptions\ZatcaStorageException;
+
+class StorageTest extends TestCase
+{
+    private string $testDir = __DIR__ . '/test_storage';
+    private string $testFile = 'test.txt';
+    private Storage $storage;
+
+    /**
+     * Set up test environment.
+     */
+    protected function setUp(): void
+    {
+        // Set test storage directory
+        Storage::setBasePath($this->testDir);
+        $this->storage = new Storage();
+
+        // Remove test directory before each test
+        if (is_dir($this->testDir)) {
+            $this->deleteDirectory($this->testDir);
+        }
+    }
+
+    /**
+     * Clean up after each test.
+     */
+    protected function tearDown(): void
+    {
+        // Remove test directory after each test
+        if (is_dir($this->testDir)) {
+            $this->deleteDirectory($this->testDir);
+        }
+    }
+
+    /**
+     * Recursively delete a directory.
+     *
+     * @param string $dir Directory path.
+     */
+    private function deleteDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $files = array_diff(scandir($dir), ['.', '..']);
+        foreach ($files as $file) {
+            $filePath = $dir . DIRECTORY_SEPARATOR . $file;
+            is_dir($filePath) ? $this->deleteDirectory($filePath) : unlink($filePath);
+        }
+        rmdir($dir);
+    }
+
+    /**
+     * Test file writing and reading.
+     */
+    public function testPutAndGet(): void
+    {
+        $content = "Hello, PHPUnit!";
+        $this->storage->put($this->testFile, $content);
+
+        $this->assertFileExists($this->storage->path($this->testFile));
+        $this->assertSame($content, $this->storage->get($this->testFile));
+    }
+
+    /**
+     * Test appending data to a file.
+     */
+    public function testAppend(): void
+    {
+        $this->storage->put($this->testFile, "Line 1");
+        $this->storage->append($this->testFile, "\nLine 2");
+
+        $expectedContent = "Line 1\nLine 2";
+        $this->assertSame($expectedContent, $this->storage->get($this->testFile));
+    }
+
+    /**
+     * Test file existence check.
+     */
+    public function testExists(): void
+    {
+        $this->assertFalse($this->storage->exists($this->testFile));
+
+        $this->storage->put($this->testFile, "Test content");
+        $this->assertTrue($this->storage->exists($this->testFile));
+    }
+
+    /**
+     * Test path generation.
+     */
+    public function testPath(): void
+    {
+        $expectedPath = $this->testDir . DIRECTORY_SEPARATOR . $this->testFile;
+        $this->assertSame($expectedPath, $this->storage->path($this->testFile));
+    }
+
+    /**
+     * Test setting and using a global base path.
+     */
+    public function testSetBasePath(): void
+    {
+        $newPath = __DIR__ . '/new_storage';
+        Storage::setBasePath($newPath);
+        $storage = new Storage();
+
+        $this->assertSame($newPath . DIRECTORY_SEPARATOR . $this->testFile, $storage->path($this->testFile));
+    }
+
+    /**
+     * Test exception when reading a non-existent file.
+     */
+    public function testGetThrowsExceptionForNonExistentFile(): void
+    {
+        $this->expectException(ZatcaStorageException::class);
+        $this->expectExceptionMessage("File not found.");
+
+        $this->storage->get('non_existent.txt');
+    }
+
+    /**
+     * Test exception when writing to a non-writable directory.
+     */
+    public function testPutThrowsExceptionOnFailure(): void
+    {
+        $this->expectException(ZatcaStorageException::class);
+        $this->expectExceptionMessage("Directory exists but is not writable.");
+
+        // Ensure test directory does not exist
+        $unwritableDir = sys_get_temp_dir() . '/unwritable_dir';
+        if (is_dir($unwritableDir)) {
+            chmod($unwritableDir, 0755);
+            rmdir($unwritableDir);
+        }
+
+        // Create read-only directory
+        mkdir($unwritableDir, 0444); // Read-only
+
+        try {
+            $storage = new Storage($unwritableDir);
+            $storage->put('test.txt', 'Should fail');
+        } finally {
+            chmod($unwritableDir, 0755); // Restore permissions before deleting
+            rmdir($unwritableDir);
+        }
+    }
+
+    /**
+     * Test exception when trying to create a directory in a read-only filesystem.
+     */
+    public function testEnsureDirectoryExistsThrowsExceptionOnFailure(): void
+    {
+        $this->expectException(ZatcaStorageException::class);
+        $this->expectExceptionMessage("Parent directory is not writable.");
+
+        // Ensure test directory does not exist
+        $unwritableDir = sys_get_temp_dir() . '/unwritable_dir';
+        if (is_dir($unwritableDir)) {
+            chmod($unwritableDir, 0755);
+            rmdir($unwritableDir);
+        }
+
+        // Create read-only directory
+        mkdir($unwritableDir, 0444); // Read-only
+
+        try {
+            $storage = new Storage($unwritableDir);
+            $storage->put('subdir/test.txt', 'Should fail');
+        } finally {
+            chmod($unwritableDir, 0755); // Restore permissions before deleting
+            rmdir($unwritableDir);
+        }
+    }
+}


### PR DESCRIPTION
- Created "Storage" for handing working with files.
- Removed unnecessary `echo` statement in `saveXMLFile`.
- Fixed issue when saving a file with a specific path without using "output".
- Fixed file path handling issue on Windows OS.
- Fixed "$json_data" ([0] issue) in README.md.

For tests:
composer test tests/StorageTest.php