### PR TITLE
fix: invoice issue time

### DIFF
--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -659,7 +659,7 @@ class Invoice implements XmlSerializable
         }
         // IssueTime
         if ($this->issueTime !== null) {
-            $writer->write([Schema::CBC . 'IssueTime' => $this->issueTime->format('H:i:s')]);
+            $writer->write([Schema::CBC . 'IssueTime' => $this->issueTime->format('H:i:s\Z')]);
         }
         // InvoiceType
         if ($this->invoiceType !== null) {

--- a/src/Mappers/InvoiceMapper.php
+++ b/src/Mappers/InvoiceMapper.php
@@ -2,6 +2,7 @@
 namespace Saleh7\Zatca\Mappers;
 
 use DateTime;
+use DateTimeZone;
 use Saleh7\Zatca\{
     Invoice, UBLExtensions, Signature, InvoiceType, TaxTotal, LegalMonetaryTotal, Delivery, AllowanceCharge, BillingReference
 };
@@ -344,13 +345,21 @@ class InvoiceMapper
      */
     private function mapDateTime(?string $dateTimeStr): DateTime
     {
+        // target timezone: UTC
+        $utc = new DateTimeZone('UTC');
+
         if (empty($dateTimeStr)) {
-            return new DateTime();
+            return new DateTime('now', $utc);
         }
+
         try {
-            return new DateTime($dateTimeStr);
+            $dt = new DateTime($dateTimeStr);
+            $dt->setTimezone($utc);
+
+            return $dt;
         } catch (\Exception $e) {
-            return new DateTime();
+            // On error, return current UTC date/time
+            return new DateTime('now', $utc);
         }
     }
 }


### PR DESCRIPTION
hi @Saleh7 

in `InvoiceExtension` we have this line:

```php
$issueTime = stripos($issueTime, 'Z') === false ? $issueTime . 'Z' : $issueTime;
```

so as I understand we always expect UTC time from the user and we add `Z` when it's not there.
however in `Invoice` we are not adding `Z` to the `IssueTime` which causes the compliance check to fail for the simplified invoices with the following warning:

```json
{
    "type": "WARNING",
    "code": "invoiceTimeStamp_QRCODE_INVALID",
    "category": "QRCODE_VALIDATION",
    "message": "Time on QR Code does not match with Invoice Issue Time (KSA-25). If ZATCA's SDK was used to generate QR Code, kindly use the latest version of SDK",
     "status": "WARNING"
}
```

after i added `Z`, the issue is resolved

It would be nice if you can review it soon.

@sevaske I adopt your code for `mapDateTime`